### PR TITLE
[codex] fix package build against VChart theme contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ tsconfig.tsbuildinfo
 common/scripts/pre-commit
 
 .vite
+.omx/

--- a/packages/vchart-aurora-theme/src/common/component/tooltip.ts
+++ b/packages/vchart-aurora-theme/src/common/component/tooltip.ts
@@ -1,6 +1,6 @@
-import type { ITooltipTheme } from '@visactor/vchart';
+import type { IComponentTheme } from '@visactor/vchart';
 
-export const tooltip: ITooltipTheme = {
+export const tooltip: IComponentTheme['tooltip'] = {
   panel: {
     border: {
       radius: 8

--- a/packages/vchart-theme/src/mobile/common/component/map-label.ts
+++ b/packages/vchart-theme/src/mobile/common/component/map-label.ts
@@ -1,6 +1,6 @@
-import type { IMapLabelTheme } from '@visactor/vchart';
+import type { IComponentTheme } from '@visactor/vchart';
 
-export const mapLabel: IMapLabelTheme = {
+export const mapLabel: IComponentTheme['mapLabel'] = {
   visible: true,
   offset: 12,
   position: 'top',


### PR DESCRIPTION
## What changed

- Use `IComponentTheme['tooltip']` for the Aurora tooltip theme so `mark` and `dimension` remain typed through the component theme contract.
- Use `IComponentTheme['mapLabel']` for the mobile map-label theme instead of importing a narrow type that VChart no longer exports.
- Ignore local `.omx/` state files.

## Why

The release build failed because VChart 2.x does not export `IMapLabelTheme`, and `ITooltipTheme` itself does not include `mark` / `dimension`. Local VChart source confirms `mark` and `dimension` are still accepted functionally through `IComponentTheme['tooltip']` and consumed by tooltip runtime logic.

## Validation

- `node common/scripts/install-run-rush.js build --only @visactor/vchart-aurora-theme --verbose`
- `node ../../common/scripts/install-run-rushx.js compile` in `packages/vchart-aurora-theme`
- `node common/scripts/install-run-rush.js build --only tag:package`
- `git diff --check`

The full package build completed with `SUCCESS WITH WARNINGS: 9 operations`; warnings are existing Rollup/Browserslist/sourcemap warnings, not blocking build errors.
